### PR TITLE
Feat/custom styling

### DIFF
--- a/packages/core/src/views/didit-socials-view/index.ts
+++ b/packages/core/src/views/didit-socials-view/index.ts
@@ -23,7 +23,11 @@ export class DiditSocialsView extends LitElement {
   // -- State & Properties -------------------------------- //
   @state() private connectors = ConnectorController.state.connectors
 
-  @property({ type: String }) public socialButtonPrefix? = 'Signin with'
+  @property({ type: String, attribute: 'social-button-prefix' })
+  public socialButtonPrefix? = 'Signin with'
+
+  @property({ type: String, attribute: 'custom-style' })
+  public customStyle?: string
 
   public constructor() {
     super()
@@ -38,11 +42,7 @@ export class DiditSocialsView extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    return html`
-      <ui-flex gap="s" flexWrap="wrap" alignItems="center">
-        ${this.connectSocialsTemplate()}
-      </ui-flex>
-    `
+    return html` ${this.connectSocialsTemplate()} `
   }
 
   // -- Private ------------------------------------------- //
@@ -56,21 +56,45 @@ export class DiditSocialsView extends LitElement {
       return null
     }
 
+    const customStyle = this.customStyle ? JSON.parse(this.customStyle) : null
+
     return html`
       ${socialConnectors.map(
         connector => html`
-          <ui-button
-            data-provider=${connector.provider}
-            variant=${this.getButtonVariant(connector.type)}
-            icon=${connector.type}
-            data-testid=${`socail-selector-${connector.id}`}
-            @click=${() => this.onConnector(connector)}
+          <ui-flex
+            custom-style=${this.getUiStyle(customStyle, connector.name, 'ui-flex')}
           >
-            ${`${this.socialButtonPrefix} ${connector.name}`}
-          </ui-button>
+            <ui-button
+              custom-style=${this.getUiStyle(customStyle, connector.name, 'ui-button')}
+              data-provider=${connector.provider}
+              variant=${this.getButtonVariant(connector.type)}
+              icon=${connector.type}
+              data-testid=${`socail-selector-${connector.id}`}
+              @click=${() => this.onConnector(connector)}
+            >
+              ${`${this.socialButtonPrefix} ${connector.name}`}
+            </button>
+          </ui-flex>
         `
       )}
     `
+  }
+
+  private getUiStyle(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    customStyle: Record<string, any>,
+    connectorName: string,
+    element: string
+  ): string {
+    if (
+      customStyle &&
+      connectorName.toLowerCase() in customStyle &&
+      element in customStyle[connectorName.toLowerCase()]
+    ) {
+      return JSON.stringify(customStyle[connectorName.toLowerCase()][element])
+    }
+
+    return ''
   }
 
   private getButtonVariant(type: SocialConnectorType) {

--- a/packages/ui/src/components/ui-button/index.ts
+++ b/packages/ui/src/components/ui-button/index.ts
@@ -16,6 +16,9 @@ export class UiButton extends LitElement {
 
   // -- State & Properties -------------------------------- //
 
+  @property({ attribute: 'custom-style' })
+  public customStyle?: string
+
   @property() public variant: ButtonVariant = 'default'
 
   @property() public icon?: IconType
@@ -36,6 +39,16 @@ export class UiButton extends LitElement {
       --local-width: ${this.fullWidth ? '100%' : 'auto'};
       --local-left-padding: ${this.centerText ? 'var(--ui-spacing-1xs)' : 'var(--ui-spacing-l)'};
     `
+    let customStyleString = ''
+    if (this.customStyle) {
+      const customStyle = JSON.parse(this.customStyle)
+
+      customStyleString = Object.keys(customStyle).reduce((acc, key) => {
+        const cssKey = key.replace(/[A-Z]/gu, m => `-${m.toLowerCase()}`)
+
+        return `${acc}${acc ? '; ' : ''}${cssKey}: ${customStyle[key]}`
+      }, '')
+    }
 
     const classes = {
       [`button-${this.variant}`]: true
@@ -46,7 +59,12 @@ export class UiButton extends LitElement {
     const textAlign = this.centerText ? 'center' : 'left'
 
     return html`
-      <button class=${classMap(classes)} ?disabled=${this.disabled} ontouchstart>
+      <button
+        style=${customStyleString}
+        class=${classMap(classes)}
+        ?disabled=${this.disabled}
+        ontouchstart
+      >
         <ui-text align=${textAlign} variant=${textVariant} color="inherit">
           <slot></slot>
         </ui-text>

--- a/packages/ui/src/layout/ui-flex/index.ts
+++ b/packages/ui/src/layout/ui-flex/index.ts
@@ -20,6 +20,9 @@ export class UiFlex extends LitElement {
   public static override styles = [resetStyles, styles]
 
   // -- State & Properties -------------------------------- //
+  @property({ attribute: 'custom-style' })
+  public customStyle?: string
+
   @property() public flexDirection?: FlexDirectionType
 
   @property() public flexWrap?: FlexWrapType
@@ -66,6 +69,19 @@ export class UiFlex extends LitElement {
       margin-bottom: ${this.margin && UiHelperUtil.getSpacingStyles(this.margin, 2)};
       margin-left: ${this.margin && UiHelperUtil.getSpacingStyles(this.margin, 3)};
     `
+    if (this.customStyle) {
+      const customStyle = JSON.parse(this.customStyle)
+
+      const customStyleString = Object.keys(customStyle).reduce((acc, key) => {
+        const cssKey = key.replace(/[A-Z]/gu, m => `-${m.toLowerCase()}`)
+
+        return `${acc}${acc ? '; ' : ''}${cssKey}: ${customStyle[key]}`
+      }, '')
+
+      if (customStyleString) {
+        this.style.cssText += this.style.cssText ? `; ${customStyleString}` : customStyleString
+      }
+    }
 
     return html`<slot></slot>`
   }


### PR DESCRIPTION
Allow custom styles to be passed as atributes to ui-flex and ui-button
Allow custom style to be passed as an attribute to didit socials view

Example:
<didit-socials-view
        custom-style={JSON.stringify({
          apple: {
            'ui-button': {
              color: 'yellow !important'
            }
          }
        })}
        social-button-prefix="lets gooo"
      ></didit-socials-view>
      
  It will work with any other connector
  [connector name] [ui-button | ui-flex][css] stringified